### PR TITLE
improve zarr-writing from hdf5-backed AnnData

### DIFF
--- a/anndata/base.py
+++ b/anndata/base.py
@@ -1936,13 +1936,14 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
         obs_rec, uns_obs = df_to_records_fixed_width(self._obs)
         var_rec, uns_var = df_to_records_fixed_width(self._var)
         d = {
-            'X': self._X,
             'obs': obs_rec,
             'var': var_rec,
+            'X': self.X,
             'obsm': self._obsm,
             'varm': self._varm,
             # add the categories to the unstructured annotation
-            'uns': {**self._uns, **uns_obs, **uns_var}}
+            'uns': {**self._uns, **uns_obs, **uns_var}
+        }
 
         if self.raw is not None:
             # we ignore categorical data types here


### PR DESCRIPTION
I converted a local 10X HDF5 to `.h5ad`, and then to `.zarr`, and needed most of these changes for the last step.

My tentative theory is that that hit some code-paths that were not the ones you tested, so that this is all additive with your previous work.

However, it could be I've broken other things here! I can work on getting some end-to-end tests and CI together to avoid thrashing going forward, but wanted to get this posted first.

I'll file a PR on single-cell-experiments shortly that uses this commit, as well.